### PR TITLE
Rename `azureSaveConfig` => `azureAdSaveConfig`

### DIFF
--- a/src/public/web-app/admin/authentication/controller.js
+++ b/src/public/web-app/admin/authentication/controller.js
@@ -87,7 +87,7 @@ angular
             };
         }
 
-        function azureSaveConfig() {
+        function azureAdSaveConfig() {
             $scope.isWorking = true;
             if (request) request.abort();
             request = ConfigService.post("azure", $scope.admin.azure);


### PR DESCRIPTION
At line 149, `$scope.save` calls `azureAdSaveConfig`, but this function was named `azureSaveConfig` (without the `Ad`). As a result, AzureAD config is never saved.